### PR TITLE
fix new timers

### DIFF
--- a/plugins/sip/list.json
+++ b/plugins/sip/list.json
@@ -103,7 +103,7 @@
         },
         {
             "name": "OpenIP",
-            "version": "0.1",
+            "version": "0.2",
             "slug": "openipv1",
             "url": "https://www.openip.fr",
             "country": "FR",

--- a/plugins/sip/openipv1/endpoint/body.json
+++ b/plugins/sip/openipv1/endpoint/body.json
@@ -6,9 +6,9 @@
     "endpoint_section_options": [
         ["identify_by", "header,auth_username,username"],
         ["allow", "!all,alaw"],
-	["contact_user", "{{ username }}"],
-	["timers_sess_expires", "1800"],
-	["timers_min_se", "1200"]
+        ["contact_user", "{{ username }}"],
+        ["timers_sess_expires", "1800"],
+        ["timers_min_se", "1200"]
     ],
     "registration_section_options": [
         ["contact_user", "{{ username }}"],

--- a/plugins/sip/openipv1/endpoint/body.json
+++ b/plugins/sip/openipv1/endpoint/body.json
@@ -5,7 +5,10 @@
     "templates": [{"uuid": "{{ global_sip_template_uuid }}"}, {"uuid":"{{ registration_trunk_sip_template_uuid }}"}],
     "endpoint_section_options": [
         ["identify_by", "header,auth_username,username"],
-        ["allow", "!all,alaw"]
+        ["allow", "!all,alaw"],
+	["contact_user", "{{ username }}"],
+	["timers_sess_expires", "1800"],
+	["timers_min_se", "1200"]
     ],
     "registration_section_options": [
         ["contact_user", "{{ username }}"],


### PR DESCRIPTION
Call crashes have been identified when some timers are not correct, we correct the timers by those recommended by OpenIP