### PR TITLE
change proxy

### DIFF
--- a/plugins/sip/list.json
+++ b/plugins/sip/list.json
@@ -103,7 +103,7 @@
         },
         {
             "name": "OpenIP",
-            "version": "0.2",
+            "version": "0.3",
             "slug": "openipv1",
             "url": "https://www.openip.fr",
             "country": "FR",

--- a/plugins/sip/openipv1/endpoint/body.json
+++ b/plugins/sip/openipv1/endpoint/body.json
@@ -14,8 +14,8 @@
         ["contact_user", "{{ username }}"],
         ["expiration", "60"],
         ["line", "yes"],
-        ["client_uri", "sip:{{ username }}@voip.myopenip.fr:5060"],
-        ["server_uri", "sip:voip.myopenip.fr:5060"]
+        ["client_uri", "sip:{{ username }}@voip03.myopenip.fr:5060"],
+        ["server_uri", "sip:voip03.myopenip.fr:5060"]
     ],
     "registration_outbound_auth_section_options": [
         ["username", "{{ username }}"],
@@ -26,10 +26,10 @@
         ["password", "{{ password }}"]
     ],
     "aor_section_options": [
-        ["contact", "sip:{{ username }}@voip.myopenip.fr:5060"]
+        ["contact", "sip:{{ username }}@voip03.myopenip.fr:5060"]
     ],
     "identify_section_options": [
         ["match_header", "Contact: /<sip:{{ username }}@.*>/"],
-        ["match", "voip.myopenip.fr"]
+        ["match", "voip03.myopenip.fr"]
     ]
 }


### PR DESCRIPTION
OpenIP communication : 
Dans le cadre de l'amélioration continue de nos services et en raison de l'incident voix du 25/08/2021 nous vous informons de la nécessité de modifier les anciennes adresses IP et domaines d'enregistrement des SIP Trunk  par le nom de domaine voip03.myopenip.fr 